### PR TITLE
fix: correct origin parsing and typing in CORS setup

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -17,7 +17,10 @@ async function bootstrap() {
   // Register fastify plugins (using Express adapter under the hood is fine)
   // If using Fastify adapter, adjust accordingly.
   // CORS
-  const origins = (process.env.ALLOWED_ORIGINS || '').split(',').map(s => s.trim()).filter(Boolean);
+  const origins = (process.env.ALLOWED_ORIGINS || '')
+    .split(',')
+    .map((s: string) => s.trim())
+    .filter(Boolean);
   app.enableCors({ origin: origins.length ? origins : true, credentials: true });
 
   const port = process.env.PORT ? Number(process.env.PORT) : 4000;


### PR DESCRIPTION
## Summary
- fix origin parsing to avoid comma operator and add explicit string typing

## Testing
- `npm run build` *(fails: Cannot find module '@nestjs/common')*

------
https://chatgpt.com/codex/tasks/task_e_689bfb29486483279728c726be3844aa